### PR TITLE
Add support for Python 3.11 & Django 4.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: xenial
+dist: jammy
 language: python
 sudo: false
 cache: pip
@@ -8,6 +8,9 @@ python:
   - 3.6
   - 3.7
   - 3.8
+  - 3.9
+  - 3.10
+  - 3.11
 
 install:
     - pip install tox tox-travis

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+django-fsm unreleased
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- add support for django 4.2
+- add support for python 3.11
+
 django-fsm 2.8.1 2022-08-15
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ setup(
         "Framework :: Django :: 3.2",
         "Framework :: Django :: 4.0",
         "Framework :: Django :: 4.1",
+        "Framework :: Django :: 4.2",
         'Programming Language :: Python',
         'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
@@ -48,7 +49,7 @@ setup(
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
-        'Framework :: Django',
+        'Programming Language :: Python :: 3.11',
         'Topic :: Software Development :: Libraries :: Python Modules',
     ]
 )

--- a/tox.ini
+++ b/tox.ini
@@ -3,10 +3,14 @@ envlist =
     # py26-dj{16}
     py27-dj{16,18,19,110,111}
     # py33-dj{16,18}
-    py{34,35,36}-dj{18,19,110,111}
-    py{36,37}-dj{20,21}
-    py{37,38,39}-dj{22,30,31,32}
-    py{38,39,310}-dj{40,41}
+    py34-dj{18,19,110,111}
+    py35-dj{18,19,110,111}
+    py36-dj{18,19,110,111,20,21}
+    py37-dj{20,21,22,30,31,32}
+    py38-dj{22,30,31,32,40,41,42}
+    py39-dj{22,30,31,32,40,41,42}
+    py310-dj{32,40,41,42}
+    py311-dj{41,42}
 skipsdist = True
 
 [testenv]
@@ -32,7 +36,7 @@ deps =
     dj110: coverage==4.1
     dj110: django-guardian==1.4.4
 
-    dj111: Django==1.11.26
+    dj111: Django==1.11.29
     dj111: coverage==4.5.4
     dj111: django-guardian==1.4.8
 
@@ -44,7 +48,7 @@ deps =
     dj21: coverage==4.5.4
     dj21: django-guardian==1.5.0
 
-    dj22: Django==2.2.24
+    dj22: Django==2.2.28
     dj22: coverage==4.5.4
     dj22: django-guardian==2.1.0
 
@@ -52,25 +56,29 @@ deps =
     dj30: coverage==4.5.4
     dj30: django-guardian==2.1.0
 
-    dj31: Django==3.1.13
+    dj31: Django==3.1.14
     dj31: coverage==5.5
     dj31: django-guardian==2.3.0
 
-    dj32: Django==3.2.9
+    dj32: Django==3.2.20
     dj32: coverage==6.1.1
     dj32: django-guardian==2.4.0
 
-    dj40: Django==4.0.7
+    dj40: Django==4.0.10
     dj40: coverage==6.4.2
     dj40: django-guardian==2.4.0
 
-    dj41: Django==4.1
+    dj41: Django==4.1.10
     dj41: coverage==6.4.3
     dj41: django-guardian==2.4.0
 
-    graphviz==0.7.1
+    dj42: Django==4.2.5
+    dj42: coverage==7.2.7
+    dj42: django-guardian==2.4.0
+
+    graphviz==0.20.1
     pep8==1.7.1
-    pyflakes==1.6.0
+    pyflakes==3.1.0
 commands = {posargs:python ./tests/manage.py test}
 
 


### PR DESCRIPTION
Backport PR https://github.com/viewflow/django-fsm/pull/297

Hi,

This PR adds python 3.11 & Django 4.2 to tests

Please can we have a new release after this PR is merged.

Thanks,