### PR TITLE
Enable CI on GitHub

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,26 @@
+name: django-fsm testing
+
+on:
+  - push
+  - pull_request
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        python-version: ['2.7', '3.4', '3.5', '3.6', '3.7', '3.8', '3.9', '3.10']
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install tox tox-gh-actions
+    - name: Test with tox
+      run: tox

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ['2.7', '3.4', '3.5', '3.6', '3.7', '3.8', '3.9', '3.10']
+        python-version: ['2.7', '3.5', '3.6', '3.7', '3.8', '3.9', '3.10']
 
     steps:
     - uses: actions/checkout@v1

--- a/tox.ini
+++ b/tox.ini
@@ -67,7 +67,6 @@ deps =
     graphviz==0.7.1
     pep8==1.7.1
     pyflakes==1.6.0
-    ipdb==0.10.3
 commands = {posargs:python ./tests/manage.py test}
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -73,3 +73,14 @@ commands = {posargs:python ./tests/manage.py test}
 
 [flake8]
 max-line-length = 130
+
+[gh-actions]
+python =
+    2.7: py27
+    3.4: py34
+    3.5: py35
+    3.6: py36
+    3.7: py37
+    3.8: py38
+    3.9: py39
+    3.10: py310

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ envlist =
     # py26-dj{16}
     py27-dj{16,18,19,110,111}
     # py33-dj{16,18}
-    py{34,35,36}-dj{18,19,110,111}
+    py{35,36}-dj{18,19,110,111}
     py{36,37}-dj{20,21}
     py{37,38,39}-dj{22,30,31,32}
     py{38,39,310}-dj{40}
@@ -13,7 +13,7 @@ skipsdist = True
 deps =
     py26: ipython==2.1.0
     {py27,py32,py33}: ipython==5.4.1
-    {py34,py35,py36}: ipython==6.1.0
+    {py35,py36}: ipython==6.1.0
     {py37}: ipython==7.4.0
 
     dj16: Django==1.6.11
@@ -77,7 +77,6 @@ max-line-length = 130
 [gh-actions]
 python =
     2.7: py27
-    3.4: py34
     3.5: py35
     3.6: py36
     3.7: py37


### PR DESCRIPTION
Backport https://github.com/viewflow/django-fsm/pull/286

Fix https://github.com/viewflow/django-fsm/issue/285, enable CI on GitHub