### PR TITLE
Test and fix graph_transition command

### DIFF
--- a/django_fsm/management/commands/graph_transitions.py
+++ b/django_fsm/management/commands/graph_transitions.py
@@ -35,27 +35,28 @@ def generate_dot(fields_data):  # noqa: C901, PLR0912
 
         # dump nodes and edges
         for transition in field.get_all_transitions(model):
-            if transition.source == "*":
-                any_targets.add((transition.target, transition.name))
-            elif transition.source == "+":
-                any_except_targets.add((transition.target, transition.name))
-            else:
-                _targets = (
-                    (state for state in transition.target.allowed_states)
-                    if isinstance(transition.target, (GET_STATE, RETURN_VALUE))
-                    else (transition.target,)
-                )
-                source_name_pair = (
-                    ((state, node_name(field, state)) for state in transition.source.allowed_states)
-                    if isinstance(transition.source, (GET_STATE, RETURN_VALUE))
-                    else ((transition.source, node_name(field, transition.source)),)
-                )
-                for source, source_name in source_name_pair:
-                    if transition.on_error:
-                        on_error_name = node_name(field, transition.on_error)
-                        targets.add((on_error_name, node_label(field, transition.on_error)))
-                        edges.add((source_name, on_error_name, (("style", "dotted"),)))
-                    for target in _targets:
+            _targets = list(
+                (state for state in transition.target.allowed_states)
+                if isinstance(transition.target, (GET_STATE, RETURN_VALUE))
+                else (transition.target,)
+            )
+            source_name_pair = (
+                ((state, node_name(field, state)) for state in transition.source.allowed_states)
+                if isinstance(transition.source, (GET_STATE, RETURN_VALUE))
+                else ((transition.source, node_name(field, transition.source)),)
+            )
+            for source, source_name in source_name_pair:
+                if transition.on_error:
+                    on_error_name = node_name(field, transition.on_error)
+                    targets.add((on_error_name, node_label(field, transition.on_error)))
+                    edges.add((source_name, on_error_name, (("style", "dotted"),)))
+
+                for target in _targets:
+                    if transition.source == "*":
+                        any_targets.add((target, transition.name))
+                    elif transition.source == "+":
+                        any_except_targets.add((target, transition.name))
+                    else:
                         add_transition(source, target, transition.name, source_name, field, sources, targets, edges)
 
         targets.update(

--- a/tests/testapp/models.py
+++ b/tests/testapp/models.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from django.db import models
 
+from django_fsm import GET_STATE
+from django_fsm import RETURN_VALUE
 from django_fsm import FSMField
 from django_fsm import FSMKeyField
 from django_fsm import transition
@@ -15,28 +17,69 @@ class Application(models.Model):
 
     state = FSMField(default="new")
 
-    @transition(field=state, source="new", target="draft")
-    def draft(self):
+    @transition(field=state, source="new", target="published")
+    def standard(self):
         pass
 
-    @transition(field=state, source=["new", "draft"], target="dept")
-    def submitted(self):
+    @transition(field=state, source="published")
+    def no_target(self):
         pass
 
-    @transition(field=state, source="dept", target="dean")
-    def dept_approved(self):
+    @transition(field=state, source="*", target="blocked")
+    def any_source(self):
         pass
 
-    @transition(field=state, source="dept", target="new")
-    def dept_rejected(self):
+    @transition(field=state, source="+", target="hidden")
+    def any_source_except_target(self):
         pass
 
-    @transition(field=state, source="dean", target="done")
-    def dean_approved(self):
+    @transition(
+        field=state,
+        source="new",
+        target=GET_STATE(
+            lambda _, allowed: "published" if allowed else "rejected",
+            states=["published", "rejected"],
+        ),
+    )
+    def get_state(self, *, allowed: bool):
         pass
 
-    @transition(field=state, source="dean", target="dept")
-    def dean_rejected(self):
+    @transition(
+        field=state,
+        source="*",
+        target=GET_STATE(
+            lambda _, allowed: "published" if allowed else "rejected",
+            states=["published", "rejected"],
+        ),
+    )
+    def get_state_any_source(self, *, allowed: bool):
+        pass
+
+    @transition(
+        field=state,
+        source="+",
+        target=GET_STATE(
+            lambda _, allowed: "published" if allowed else "rejected",
+            states=["published", "rejected"],
+        ),
+    )
+    def get_state_any_source_except_target(self, *, allowed: bool):
+        pass
+
+    @transition(field=state, source="new", target=RETURN_VALUE("moderated", "blocked"))
+    def return_value(self):
+        return "published"
+
+    @transition(field=state, source="*", target=RETURN_VALUE("moderated", "blocked"))
+    def return_value_any_source(self):
+        return "published"
+
+    @transition(field=state, source="+", target=RETURN_VALUE("moderated", "blocked"))
+    def return_value_any_source_except_target(self):
+        return "published"
+
+    @transition(field=state, source="new", target="published", on_error="failed")
+    def on_error(self):
         pass
 
 
@@ -61,28 +104,69 @@ class FKApplication(models.Model):
 
     state = FSMKeyField(DbState, default="new", on_delete=models.CASCADE)
 
-    @transition(field=state, source="new", target="draft")
-    def draft(self):
+    @transition(field=state, source="new", target="published")
+    def standard(self):
         pass
 
-    @transition(field=state, source=["new", "draft"], target="dept")
-    def submitted(self):
+    @transition(field=state, source="published")
+    def no_target(self):
         pass
 
-    @transition(field=state, source="dept", target="dean")
-    def dept_approved(self):
+    @transition(field=state, source="*", target="blocked")
+    def any_source(self):
         pass
 
-    @transition(field=state, source="dept", target="new")
-    def dept_rejected(self):
+    @transition(field=state, source="+", target="hidden")
+    def any_source_except_target(self):
         pass
 
-    @transition(field=state, source="dean", target="done")
-    def dean_approved(self):
+    @transition(
+        field=state,
+        source="new",
+        target=GET_STATE(
+            lambda _, allowed: "published" if allowed else "rejected",
+            states=["published", "rejected"],
+        ),
+    )
+    def get_state(self, *, allowed: bool):
         pass
 
-    @transition(field=state, source="dean", target="dept")
-    def dean_rejected(self):
+    @transition(
+        field=state,
+        source="*",
+        target=GET_STATE(
+            lambda _, allowed: "published" if allowed else "rejected",
+            states=["published", "rejected"],
+        ),
+    )
+    def get_state_any_source(self, *, allowed: bool):
+        pass
+
+    @transition(
+        field=state,
+        source="+",
+        target=GET_STATE(
+            lambda _, allowed: "published" if allowed else "rejected",
+            states=["published", "rejected"],
+        ),
+    )
+    def get_state_any_source_except_target(self, *, allowed: bool):
+        pass
+
+    @transition(field=state, source="new", target=RETURN_VALUE("moderated", "blocked"))
+    def return_value(self):
+        return "published"
+
+    @transition(field=state, source="*", target=RETURN_VALUE("moderated", "blocked"))
+    def return_value_any_source(self):
+        return "published"
+
+    @transition(field=state, source="+", target=RETURN_VALUE("moderated", "blocked"))
+    def return_value_any_source_except_target(self):
+        return "published"
+
+    @transition(field=state, source="new", target="published", on_error="failed")
+    def on_error(self):
         pass
 
 

--- a/tests/testapp/tests/test_graph_transitions.py
+++ b/tests/testapp/tests/test_graph_transitions.py
@@ -1,49 +1,22 @@
 from __future__ import annotations
 
 from django.core.management import call_command
-from django.db import models
 from django.test import TestCase
 
-from django_fsm import FSMField
-from django_fsm import transition
-
-
-class VisualBlogPost(models.Model):
-    state = FSMField(default="new")
-
-    @transition(field=state, source="new", target="published")
-    def publish(self):
-        pass
-
-    @transition(source="published", field=state)
-    def notify_all(self):
-        pass
-
-    @transition(source="published", target="hidden", field=state)
-    def hide(self):
-        pass
-
-    @transition(source="new", target="removed", field=state)
-    def remove(self):
-        raise Exception("Upss")
-
-    @transition(source=["published", "hidden"], target="stolen", field=state)
-    def steal(self):
-        pass
-
-    @transition(source="*", target="moderated", field=state)
-    def moderate(self):
-        pass
-
-    @transition(source="+", target="blocked", field=state)
-    def block(self):
-        pass
-
-    @transition(source="*", target="", field=state)
-    def empty(self):
-        pass
+from django_fsm.management.commands.graph_transitions import get_graphviz_layouts
 
 
 class GraphTransitionsCommandTest(TestCase):
     def test_dummy(self):
-        call_command("graph_transitions", "testapp.VisualBlogPost")
+        call_command("graph_transitions", "testapp.Application")
+
+    def test_layouts(self):
+        for layout in get_graphviz_layouts():
+            call_command("graph_transitions", "-l", layout, "testapp.Application")
+
+    def test_fk_dummy(self):
+        call_command("graph_transitions", "testapp.FKApplication")
+
+    def test_fk_layouts(self):
+        for layout in get_graphviz_layouts():
+            call_command("graph_transitions", "-l", layout, "testapp.FKApplication")

--- a/tests/testapp/tests/test_transition_all_except_target.py
+++ b/tests/testapp/tests/test_transition_all_except_target.py
@@ -8,7 +8,7 @@ from django_fsm import can_proceed
 from django_fsm import transition
 
 
-class TestExceptTargetTransitionShortcut(models.Model):
+class ExceptTargetTransition(models.Model):
     state = FSMField(default="new")
 
     @transition(field=state, source="new", target="published")
@@ -22,7 +22,7 @@ class TestExceptTargetTransitionShortcut(models.Model):
 
 class Test(TestCase):
     def setUp(self):
-        self.model = TestExceptTargetTransitionShortcut()
+        self.model = ExceptTargetTransition()
 
     def test_usecase(self):
         assert self.model.state == "new"


### PR DESCRIPTION
Fixes #53

When a transition was declaring a `RETURN_VALUE` (or `GET_STATE`) as target_state, and a wildcard source (`"*"` or `"+"`) only the source was poupulated and the target wasn't.
