### PR TITLE
Track failed condition in TransitionNotAllowed

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,7 +12,8 @@ django-fsm-2 4.2.4 2026-03-16
 
 - Fix GET_STATE and RETURN_VALUE without allowed_states defined
 - Introduce ``ANY_STATE`` and ``ANY_OTHER_STATE`` constants
-- Add ``failed_condition`` attribute to ``TransitionNotAllowed`` exception
+- Add ``TransitionConditionsUnmet`` with ``failed_condition`` for unmet conditions
+- Add ``NoTransition`` and ``InvalidTransition`` subclasses for ``TransitionNotAllowed``
 
 
 django-fsm-2 4.2.3 2026-03-15

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,8 @@ Unreleased
 ~~~~~~~~~~
 
 - Update ``State.get_state`` signature to remove ``transition`` parameter (It wasn't used in ``RETURN_VALUE`` and ``GET_STATE`` and was buggy)
+- Add ``TransitionConditionsUnmet`` with ``failed_condition`` for unmet conditions
+- Add ``NoTransition`` and ``InvalidTransition`` subclasses for ``TransitionNotAllowed``
 
 
 django-fsm-2 4.2.4 2026-03-16
@@ -12,8 +14,6 @@ django-fsm-2 4.2.4 2026-03-16
 
 - Fix GET_STATE and RETURN_VALUE without allowed_states defined
 - Introduce ``ANY_STATE`` and ``ANY_OTHER_STATE`` constants
-- Add ``TransitionConditionsUnmet`` with ``failed_condition`` for unmet conditions
-- Add ``NoTransition`` and ``InvalidTransition`` subclasses for ``TransitionNotAllowed``
 
 
 django-fsm-2 4.2.3 2026-03-15

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,7 @@ django-fsm-2 4.2.4 2026-03-16
 
 - Fix GET_STATE and RETURN_VALUE without allowed_states defined
 - Introduce ``ANY_STATE`` and ``ANY_OTHER_STATE`` constants
+- Add ``failed_condition`` attribute to ``TransitionNotAllowed`` exception
 
 
 django-fsm-2 4.2.3 2026-03-15

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,8 @@ Unreleased
 - Update ``State.get_state`` signature to remove ``transition`` parameter (It wasn't used in ``RETURN_VALUE`` and ``GET_STATE`` and was buggy)
 - Add Unfold support to admin
 - Add Django 6.1 support
+- Add ``TransitionConditionsUnmet`` with ``failed_condition`` for unmet conditions
+- Add ``NoTransition`` and ``InvalidTransition`` subclasses for ``TransitionNotAllowed``
 
 
 django-fsm-2 4.2.4 2026-03-16
@@ -14,8 +16,6 @@ django-fsm-2 4.2.4 2026-03-16
 
 - Fix GET_STATE and RETURN_VALUE without allowed_states defined
 - Introduce ``ANY_STATE`` and ``ANY_OTHER_STATE`` constants
-- Add ``TransitionConditionsUnmet`` with ``failed_condition`` for unmet conditions
-- Add ``NoTransition`` and ``InvalidTransition`` subclasses for ``TransitionNotAllowed``
 
 
 django-fsm-2 4.2.3 2026-03-15

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,7 @@ django-fsm-2 4.2.4 2026-03-16
 
 - Fix GET_STATE and RETURN_VALUE without allowed_states defined
 - Introduce ``ANY_STATE`` and ``ANY_OTHER_STATE`` constants
+- Add ``failed_condition`` attribute to ``TransitionNotAllowed`` exception
 
 
 django-fsm-2 4.2.3 2026-03-15

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,7 +14,8 @@ django-fsm-2 4.2.4 2026-03-16
 
 - Fix GET_STATE and RETURN_VALUE without allowed_states defined
 - Introduce ``ANY_STATE`` and ``ANY_OTHER_STATE`` constants
-- Add ``failed_condition`` attribute to ``TransitionNotAllowed`` exception
+- Add ``TransitionConditionsUnmet`` with ``failed_condition`` for unmet conditions
+- Add ``NoTransition`` and ``InvalidTransition`` subclasses for ``TransitionNotAllowed``
 
 
 django-fsm-2 4.2.3 2026-03-15

--- a/README.md
+++ b/README.md
@@ -172,15 +172,15 @@ class XXX(fsm.FSMModelMixin, models.Model):
 ```
 
 When a transition is blocked by an unmet condition, the raised
-`TransitionNotAllowed` exception includes the failing callable in its
+`TransitionConditionsUnmet` exception includes the failing callable in its
 `failed_condition` attribute for programmatic handling:
 
 ```python
-from django_fsm import TransitionNotAllowed
+from django_fsm import TransitionConditionsUnmet
 
 try:
     instance.publish()
-except TransitionNotAllowed as e:
+except TransitionConditionsUnmet as e:
     print(e.failed_condition)  # e.g. <function can_publish at 0x...>
 ```
 

--- a/README.md
+++ b/README.md
@@ -171,6 +171,19 @@ class XXX(fsm.FSMModelMixin, models.Model):
         pass
 ```
 
+When a transition is blocked by an unmet condition, the raised
+`TransitionNotAllowed` exception includes the failing callable in its
+`failed_condition` attribute for programmatic handling:
+
+```python
+from django_fsm import TransitionNotAllowed
+
+try:
+    instance.publish()
+except TransitionNotAllowed as e:
+    print(e.failed_condition)  # e.g. <function can_publish at 0x...>
+```
+
 ### Protected state fields
 
 Use `protected=True` to prevent direct assignment. Only transitions may

--- a/django_fsm/__init__.py
+++ b/django_fsm/__init__.py
@@ -18,6 +18,12 @@ from django.db.models import QuerySet
 from django.db.models.query_utils import DeferredAttribute
 from django.db.models.signals import class_prepared
 
+from .exceptions import ConcurrentTransition
+from .exceptions import InvalidResultState
+from .exceptions import InvalidTransition
+from .exceptions import NoTransition
+from .exceptions import TransitionConditionsUnmet
+from .exceptions import TransitionNotAllowed
 from .signals import post_transition
 from .signals import pre_transition
 
@@ -65,6 +71,9 @@ __all__ = [
     "FSMIntegerField",
     "FSMKeyField",
     "FSMModelMixin",
+    "InvalidTransition",
+    "NoTransition",
+    "TransitionConditionsUnmet",
     "TransitionNotAllowed",
     "can_proceed",
     "has_transition_perm",
@@ -74,29 +83,6 @@ __all__ = [
 
 ANY_STATE = "*"
 ANY_OTHER_STATE = "+"
-
-
-class TransitionNotAllowed(Exception):  # noqa: N818
-    """Raised when a transition is not allowed"""
-
-    @override
-    def __init__(self, *args: typing.Any, **kwargs: typing.Any) -> None:
-        self.object = kwargs.pop("object", None)
-        self.method = kwargs.pop("method", None)
-        self.failed_condition = kwargs.pop("failed_condition", None)
-        super().__init__(*args, **kwargs)
-
-
-class InvalidResultState(Exception):  # noqa: N818
-    """Raised when we got invalid result state"""
-
-
-class ConcurrentTransition(Exception):  # noqa: N818
-    """
-    Raised when the transition cannot be executed because the
-    object has become stale (state has been changed since it
-    was fetched from the database).
-    """
 
 
 class Transition:
@@ -267,7 +253,7 @@ class FSMMeta:
 
         return all(condition(instance) for condition in transition.conditions)
 
-    def _get_first_unmet_condition(
+    def get_first_unmet_condition(
         self, instance: _FSMModel, state: _StateValue
     ) -> _Condition | None:
         """
@@ -300,16 +286,16 @@ class FSMMeta:
     def next_state(self, current_state: _StateValue) -> _StateValue:
         transition = self.get_transition(current_state)
 
-        if transition is None:
-            raise TransitionNotAllowed(f"No transition from {current_state}")
+        if transition is None:  # pragma: no cover
+            raise NoTransition(f"No transition from {current_state}")
 
         return transition.target
 
     def exception_state(self, current_state: _StateValue) -> _StateValue | None:
         transition = self.get_transition(current_state)
 
-        if transition is None:
-            raise TransitionNotAllowed(f"No transition from {current_state}")
+        if transition is None:  # pragma: no cover
+            raise NoTransition(f"No transition from {current_state}")
 
         return transition.on_error
 
@@ -409,14 +395,14 @@ class FSMFieldMixin(_Field):
         current_state = self.get_state(instance)
 
         if not meta.has_transition(current_state):
-            raise TransitionNotAllowed(
+            raise InvalidTransition(
                 f"Can't switch from state '{current_state}' using method '{method_name}'",
                 object=instance,
                 method=method,
             )
-        unmet = meta._get_first_unmet_condition(instance, current_state)
+        unmet = meta.get_first_unmet_condition(instance, current_state)
         if unmet is not None:
-            raise TransitionNotAllowed(
+            raise TransitionConditionsUnmet(
                 f"Transition conditions have not been met for method '{method_name}': "
                 f"{getattr(unmet, '__name__', repr(unmet))}",
                 object=instance,

--- a/django_fsm/__init__.py
+++ b/django_fsm/__init__.py
@@ -83,6 +83,7 @@ class TransitionNotAllowed(Exception):  # noqa: N818
     def __init__(self, *args: typing.Any, **kwargs: typing.Any) -> None:
         self.object = kwargs.pop("object", None)
         self.method = kwargs.pop("method", None)
+        self.failed_condition = kwargs.pop("failed_condition", None)
         super().__init__(*args, **kwargs)
 
 
@@ -266,6 +267,26 @@ class FSMMeta:
 
         return all(condition(instance) for condition in transition.conditions)
 
+    def _get_first_unmet_condition(
+        self, instance: _FSMModel, state: _StateValue
+    ) -> _Condition | None:
+        """
+        Return the first condition callable that is not met, or None.
+
+        Evaluates conditions in declaration order, short-circuiting on first
+        failure — identical evaluation semantics to conditions_met().
+        """
+        transition = self.get_transition(state)
+
+        if transition is None or transition.conditions is None:
+            return None
+
+        for condition in transition.conditions:
+            if not condition(instance):
+                return condition
+
+        return None
+
     def has_transition_perm(
         self, instance: _FSMModel, state: _StateValue, user: UserWithPermissions
     ) -> bool:
@@ -393,11 +414,14 @@ class FSMFieldMixin(_Field):
                 object=instance,
                 method=method,
             )
-        if not meta.conditions_met(instance, current_state):
+        unmet = meta._get_first_unmet_condition(instance, current_state)
+        if unmet is not None:
             raise TransitionNotAllowed(
-                f"Transition conditions have not been met for method '{method_name}'",
+                f"Transition conditions have not been met for method '{method_name}': "
+                f"{getattr(unmet, '__name__', repr(unmet))}",
                 object=instance,
                 method=method,
+                failed_condition=unmet,
             )
 
         next_state = meta.next_state(current_state)

--- a/django_fsm/exceptions.py
+++ b/django_fsm/exceptions.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import typing
+
+try:
+    from typing import override
+except ImportError:  # pragma: no cover
+    # Py<3.12
+    from typing_extensions import override
+
+if typing.TYPE_CHECKING:  # pragma: no cover
+    from . import _Condition
+    from . import _FSMModel
+    from . import _TransitionFunc
+
+
+class FSMException(Exception):  # noqa: N818
+    ...
+
+
+class TransitionNotAllowed(FSMException):
+    """Raised when a transition is not allowed"""
+
+
+class NoTransition(TransitionNotAllowed):
+    """Raised when no transition exists for the current state"""
+
+
+class InvalidTransition(TransitionNotAllowed):
+    """Raised when a transition method is not valid for the current state"""
+
+    object: _FSMModel
+    method: _TransitionFunc
+
+    @override
+    def __init__(self, *args: typing.Any, **kwargs: typing.Any) -> None:
+        self.object = kwargs.pop("object", None)
+        self.method = kwargs.pop("method", None)
+        super().__init__(*args, **kwargs)
+
+
+class TransitionConditionsUnmet(InvalidTransition):
+    """Raised when a transition condition fails"""
+
+    failed_condition: _Condition
+
+    @override
+    def __init__(self, *args: typing.Any, **kwargs: typing.Any) -> None:
+        self.failed_condition = kwargs.pop("failed_condition", None)
+        super().__init__(*args, **kwargs)
+
+
+class InvalidResultState(FSMException):
+    """Raised when we got invalid result state"""
+
+
+class ConcurrentTransition(FSMException):
+    """
+    Raised when the transition cannot be executed because the
+    object has become stale (state has been changed since it
+    was fetched from the database).
+    """

--- a/tests/testapp/tests/test_basic_transitions.py
+++ b/tests/testapp/tests/test_basic_transitions.py
@@ -77,7 +77,7 @@ class FSMFieldTest(TestCase):
 
     def test_unavailable_transition_fails(self):
         assert not fsm.can_proceed(self.model.hide)
-        with pytest.raises(fsm.TransitionNotAllowed):
+        with pytest.raises(fsm.InvalidTransition):
             self.model.hide()
 
     def test_state_unchanged_when_transition_raises(self):
@@ -94,7 +94,7 @@ class FSMFieldTest(TestCase):
         assert self.model.state == ApplicationState.PUBLISHED
 
     def test_unavailable_transition_with_empty_target_keeps_state(self):
-        with pytest.raises(fsm.TransitionNotAllowed):
+        with pytest.raises(fsm.InvalidTransition):
             self.model.notify_all()
 
         assert self.model.state == ApplicationState.NEW
@@ -134,7 +134,7 @@ class FSMFieldTest(TestCase):
         self.model.block()
 
         assert not fsm.can_proceed(self.model.block)
-        with pytest.raises(fsm.TransitionNotAllowed):
+        with pytest.raises(fsm.InvalidTransition):
             self.model.block()
 
     def test_empty_string_target_sets_blank_state(self):
@@ -170,7 +170,7 @@ class StateSignalsTests(TestCase):
         assert self.post_transition_called
 
     def test_signals_do_not_fire_on_invalid_transition(self):
-        with pytest.raises(fsm.TransitionNotAllowed):
+        with pytest.raises(fsm.InvalidTransition):
             self.model.hide()
 
         assert not self.pre_transition_called

--- a/tests/testapp/tests/test_conditions.py
+++ b/tests/testapp/tests/test_conditions.py
@@ -86,17 +86,19 @@ class ConditionTransitionTests(TestCase):
 
 
 def _eval_tracking_condition(instance: models.Model) -> bool:
-    instance._eval_log.append("first")
+    instance._eval_log.append("first")  # type: ignore[attr-defined]
     return False
 
 
 def _never_reached_condition(instance: models.Model) -> bool:
-    instance._eval_log.append("second")
+    instance._eval_log.append("second")  # type: ignore[attr-defined]
     return False
 
 
 class BlogPostShortCircuit(models.Model):
     state = fsm.FSMField(default="new")
+
+    _eval_log: list[str] = []
 
     @fsm.transition(
         field=state,

--- a/tests/testapp/tests/test_conditions.py
+++ b/tests/testapp/tests/test_conditions.py
@@ -66,3 +66,53 @@ class ConditionTransitionTests(TestCase):
             self.model.remove()
 
         assert fsm.can_proceed(self.model.remove, check_conditions=False)
+
+    def test_failed_condition_reported_on_exception(self):
+        self.model.publish()
+        with pytest.raises(fsm.TransitionNotAllowed) as exc_info:
+            self.model.remove()
+        assert exc_info.value.failed_condition is BlogPostWithConditions.unmet_condition
+
+    def test_failed_condition_named_in_message(self):
+        self.model.publish()
+        with pytest.raises(fsm.TransitionNotAllowed, match="unmet_condition"):
+            self.model.remove()
+
+    def test_failed_condition_is_none_when_no_condition_failure(self):
+        """TransitionNotAllowed for a missing transition has no failed_condition."""
+        with pytest.raises(fsm.TransitionNotAllowed) as exc_info:
+            self.model.remove()  # state is "new", destroy only works from "published"
+        assert exc_info.value.failed_condition is None
+
+
+def _eval_tracking_condition(instance: models.Model) -> bool:
+    instance._eval_log.append("first")
+    return False
+
+
+def _never_reached_condition(instance: models.Model) -> bool:
+    instance._eval_log.append("second")
+    return False
+
+
+class BlogPostShortCircuit(models.Model):
+    state = fsm.FSMField(default="new")
+
+    @fsm.transition(
+        field=state,
+        source="new",
+        target="published",
+        conditions=[_eval_tracking_condition, _never_reached_condition],
+    )
+    def publish(self):
+        pass
+
+
+class ShortCircuitTest(TestCase):
+    def test_only_first_failing_condition_evaluated(self):
+        obj = BlogPostShortCircuit()
+        obj._eval_log = []
+        with pytest.raises(fsm.TransitionNotAllowed) as exc_info:
+            obj.publish()
+        assert exc_info.value.failed_condition is _eval_tracking_condition
+        assert obj._eval_log == ["first"]

--- a/tests/testapp/tests/test_conditions.py
+++ b/tests/testapp/tests/test_conditions.py
@@ -62,27 +62,26 @@ class ConditionTransitionTests(TestCase):
 
         assert not fsm.can_proceed(self.model.remove)
 
-        with pytest.raises(fsm.TransitionNotAllowed):
+        with pytest.raises(fsm.TransitionConditionsUnmet):
             self.model.remove()
 
         assert fsm.can_proceed(self.model.remove, check_conditions=False)
 
     def test_failed_condition_reported_on_exception(self):
         self.model.publish()
-        with pytest.raises(fsm.TransitionNotAllowed) as exc_info:
+        with pytest.raises(fsm.TransitionConditionsUnmet) as exc_info:
             self.model.remove()
         assert exc_info.value.failed_condition is BlogPostWithConditions.unmet_condition
 
     def test_failed_condition_named_in_message(self):
         self.model.publish()
-        with pytest.raises(fsm.TransitionNotAllowed, match="unmet_condition"):
+        with pytest.raises(fsm.TransitionConditionsUnmet, match="unmet_condition"):
             self.model.remove()
 
     def test_failed_condition_is_none_when_no_condition_failure(self):
-        """TransitionNotAllowed for a missing transition has no failed_condition."""
-        with pytest.raises(fsm.TransitionNotAllowed) as exc_info:
+        """InvalidTransition for a missing transition has no failed_condition."""
+        with pytest.raises(fsm.InvalidTransition):
             self.model.remove()  # state is "new", destroy only works from "published"
-        assert exc_info.value.failed_condition is None
 
 
 def _eval_tracking_condition(instance: models.Model) -> bool:
@@ -114,7 +113,7 @@ class ShortCircuitTest(TestCase):
     def test_only_first_failing_condition_evaluated(self):
         obj = BlogPostShortCircuit()
         obj._eval_log = []
-        with pytest.raises(fsm.TransitionNotAllowed) as exc_info:
+        with pytest.raises(fsm.TransitionConditionsUnmet) as exc_info:
             obj.publish()
         assert exc_info.value.failed_condition is _eval_tracking_condition
         assert obj._eval_log == ["first"]

--- a/tests/testapp/tests/test_integer_field.py
+++ b/tests/testapp/tests/test_integer_field.py
@@ -35,5 +35,5 @@ class BlogPostWithIntegerFieldTest(TestCase):
         assert self.model.state == BlogPostState.HIDDEN
 
     def test_unknown_transition_fails(self):
-        with pytest.raises(fsm.TransitionNotAllowed):
+        with pytest.raises(fsm.InvalidTransition):
             self.model.hide()

--- a/tests/testapp/tests/test_key_field.py
+++ b/tests/testapp/tests/test_key_field.py
@@ -84,7 +84,7 @@ class FSMKeyFieldTestCase(TestCase):
     def test_unknown_transition_fails(self):
         assert not fsm.can_proceed(self.model.hide)
 
-        with pytest.raises(fsm.TransitionNotAllowed):
+        with pytest.raises(fsm.InvalidTransition):
             self.model.hide()
 
     def test_state_non_changed_after_fail(self):
@@ -104,7 +104,7 @@ class FSMKeyFieldTestCase(TestCase):
         assert self.model.state == "_PUBLISHED_"
 
     def test_unknown_null_transition_should_fail(self):
-        with pytest.raises(fsm.TransitionNotAllowed):
+        with pytest.raises(fsm.InvalidTransition):
             self.model.notify_all()
 
         assert self.model.state == "_NEW_"

--- a/tests/testapp/tests/test_permissions.py
+++ b/tests/testapp/tests/test_permissions.py
@@ -11,39 +11,39 @@ from tests.testapp.models import BlogPost
 class PermissionFSMFieldTest(TestCase):
     def setUp(self):
         self.model = BlogPost()
-        self.unprivileged = User.objects.create(username="unprivileged")
-        self.privileged = User.objects.create(username="privileged")
-        self.staff = User.objects.create(username="staff", is_staff=True)
+        self.unprivileged_user = User.objects.create(username="unprivileged")
+        self.privileged_user = User.objects.create(username="privileged")
+        self.staff_user = User.objects.create(username="staff", is_staff=True)
 
-        self.privileged.user_permissions.add(
+        self.privileged_user.user_permissions.add(
             Permission.objects.get_by_natural_key("can_publish_post", "testapp", "blogpost")
         )
-        self.privileged.user_permissions.add(
+        self.privileged_user.user_permissions.add(
             Permission.objects.get_by_natural_key("can_remove_post", "testapp", "blogpost")
         )
 
     def test_privileged_access_succeed(self):
-        assert fsm.has_transition_perm(self.model.publish, self.privileged)
-        assert fsm.has_transition_perm(self.model.remove, self.privileged)
+        assert fsm.has_transition_perm(self.model.publish, self.privileged_user)
+        assert fsm.has_transition_perm(self.model.remove, self.privileged_user)
 
         available_transitions = self.model.get_available_user_state_transitions(  # type: ignore[attr-defined]
-            self.privileged
+            self.privileged_user
         )
-        transition_names = {transition.name for transition in available_transitions}
-
-        assert {"publish", "remove", "moderate"} == transition_names
+        assert {transition.name for transition in available_transitions} == {
+            "publish",
+            "remove",
+            "moderate",
+        }
 
     def test_unprivileged_access_prohibited(self):
-        assert not fsm.has_transition_perm(self.model.publish, self.unprivileged)
-        assert not fsm.has_transition_perm(self.model.remove, self.unprivileged)
+        assert not fsm.has_transition_perm(self.model.publish, self.unprivileged_user)
+        assert not fsm.has_transition_perm(self.model.remove, self.unprivileged_user)
 
         available_transitions = self.model.get_available_user_state_transitions(  # type: ignore[attr-defined]
-            self.unprivileged
+            self.unprivileged_user
         )
-        transition_names = {transition.name for transition in available_transitions}
-
-        assert {"moderate"} == transition_names
+        assert {transition.name for transition in available_transitions} == {"moderate"}
 
     def test_permission_instance_method(self):
-        assert not fsm.has_transition_perm(self.model.restore, self.unprivileged)
-        assert fsm.has_transition_perm(self.model.restore, self.staff)
+        assert not fsm.has_transition_perm(self.model.restore, self.unprivileged_user)
+        assert fsm.has_transition_perm(self.model.restore, self.staff_user)


### PR DESCRIPTION
## Description

Failed condition tracking in TransitionNotAllowed for better diagnosis and fine-grained error handling.
Fully backwards compatible, this only adds advisory context to the exception.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Other (no functional changes)

## Checklist

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guide
- [x] Tests added/updated for the changes
- [x] All tests pass locally (`uv run pytest` or `pytest`)
- [x] Linting passes (`uv run ruff check .`)
- [x] Documentation updated (if applicable)
- [x] CHANGELOG.rst updated (for user-facing changes)

## Testing

Unittests added.
Fork tested manually in an interractive Python shell.

```bash
# Commands used to test
uv run pytest tests/test_xxx.py -v
```



