### PR TITLE
Add *args and **kwargs to _do_update method

### DIFF
--- a/django_fsm/__init__.py
+++ b/django_fsm/__init__.py
@@ -586,6 +586,8 @@ class ConcurrentTransitionMixin(FSMModelMixin):
         update_fields: typing.Iterable[str] | None,
         forced_update: bool,
         returning_fields: bool | None = None,
+        *args,
+        **kwargs,
     ) -> bool:
         # _do_update is called once for each model class in the inheritance hierarchy. We can only
         # filter the base_qs on state fields (can be more than one!) present in this specific model.
@@ -606,6 +608,8 @@ class ConcurrentTransitionMixin(FSMModelMixin):
                 update_fields=update_fields,
                 forced_update=forced_update,
                 returning_fields=returning_fields,
+                *args,
+                **kwargs,
             )
         else:
             updated = super()._do_update(
@@ -615,6 +619,8 @@ class ConcurrentTransitionMixin(FSMModelMixin):
                 values=values,
                 update_fields=update_fields,
                 forced_update=forced_update,
+                *args,
+                **kwargs,
             )
 
         # It may happen that nothing was updated in the original _do_update method not because of


### PR DESCRIPTION
During `./manage.py loaddata ...` a `TypeError` is raised:

```
TypeError: Problem installing fixture '/home/carmen/data.json': Model._do_update() takes 7 positional arguments but 8 were given
```

## Description

<!-- Briefly describe what this PR does -->

## Type of Change

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Other (no functional changes)

## Checklist

- [ ] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guide
- [ ] Tests added/updated for the changes
- [ ] All tests pass locally (`uv run pytest` or `pytest`)
- [ ] Linting passes (`uv run ruff check .`)
- [ ] Documentation updated (if applicable)
- [ ] CHANGELOG.rst updated (for user-facing changes)

## Testing

<!-- Describe how you tested these changes -->

```bash
# Commands used to test
uv run pytest tests/test_xxx.py -v
```

## Related Issues

<!-- Link any related issues: Fixes #123, Related to #456 -->
