### PR TITLE
Update get_state signature: remove misleading ‘transition‘ parameter

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,8 +4,15 @@ Changelog
 Unreleased
 ~~~~~~~~~~
 
+- Update ``State.get_state`` signature to remove ``transition`` parameter (It wasn't used in ``RETURN_VALUE`` and ``GET_STATE`` and was buggy)
+
+
+django-fsm-2 4.2.4 2026-03-16
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 - Fix GET_STATE and RETURN_VALUE without allowed_states defined
 - Introduce ``ANY_STATE`` and ``ANY_OTHER_STATE`` constants
+
 
 django-fsm-2 4.2.3 2026-03-15
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/django_fsm/__init__.py
+++ b/django_fsm/__init__.py
@@ -4,6 +4,7 @@ State tracking functionality for django models
 
 from __future__ import annotations
 
+import abc
 import inspect
 import typing
 from functools import partialmethod
@@ -399,10 +400,8 @@ class FSMFieldMixin(_Field):
         try:
             result = method(instance, *args, **kwargs)
             if next_state is not None:
-                if hasattr(next_state, "get_state"):
-                    next_state = next_state.get_state(
-                        instance, transition, result, args=args, kwargs=kwargs
-                    )
+                if isinstance(next_state, State):
+                    next_state = next_state.get_state(instance, result, args=args, kwargs=kwargs)
                     signal_kwargs["target"] = next_state
                 self.set_proxy(instance, next_state)
                 self.set_state(instance, next_state)
@@ -736,10 +735,10 @@ def has_transition_perm(bound_method: typing.Any, user: UserWithPermissions) -> 
 class State:
     allowed_states: typing.Sequence[_StateValue]
 
+    @abc.abstractmethod
     def get_state(
         self,
         model: _FSMModel,
-        transition: Transition,
         result: typing.Any,
         args: typing.Sequence[typing.Any] | None = None,
         kwargs: dict[str, typing.Any] | None = None,
@@ -751,10 +750,10 @@ class RETURN_VALUE(State):  # noqa: N801
     def __init__(self, *allowed_states: _StateValue) -> None:
         self.allowed_states = allowed_states or []
 
+    @override
     def get_state(
         self,
         model: _FSMModel,
-        transition: Transition,
         result: typing.Any,
         args: typing.Sequence[typing.Any] | None = None,
         kwargs: dict[str, typing.Any] | None = None,
@@ -775,10 +774,10 @@ class GET_STATE(State):  # noqa: N801
         self.func = func
         self.allowed_states = states or []
 
+    @override
     def get_state(
         self,
         model: _FSMModel,
-        transition: Transition,
         result: _StateValue,
         args: typing.Sequence[typing.Any] | None = None,
         kwargs: dict[str, typing.Any] | None = None,


### PR DESCRIPTION
## Description

  - Removes the transition parameter from State.get_state(), RETURN_VALUE.get_state(), and GET_STATE.get_state()                                                                                                 
  - Replaces the duck-type hasattr(next_state, "get_state") check with isinstance(next_state, State)                                                                                                          

  Motivation:

  The transition parameter was named and typed as a Transition, but what was actually passed at the call site was the transition decorator function — not a Transition instance. This was misleading to anyone implementing a custom State subclass.

  Since neither RETURN_VALUE nor GET_STATE ever used the parameter, it was safe to remove. **Anyone with a custom State subclass that accepted transition will need to drop it from their get_state signature — but given it held the wrong value, it was unlikely to be relied upon.**

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Other (no functional changes)

## Checklist

- [ ] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guide
- [ ] Tests added/updated for the changes
- [ ] All tests pass locally (`uv run pytest` or `pytest`)
- [ ] Linting passes (`uv run ruff check .`)
- [ ] Documentation updated (if applicable)
- [ ] CHANGELOG.rst updated (for user-facing changes)

## Testing

<!-- Describe how you tested these changes -->

```bash
# Commands used to test
uv run pytest tests/test_xxx.py -v
```

## Related Issues

<!-- Link any related issues: Fixes #123, Related to #456 -->
